### PR TITLE
Feature/6 support more projects for one issue

### DIFF
--- a/living_documentation_generator/generator.py
+++ b/living_documentation_generator/generator.py
@@ -230,10 +230,6 @@ class LivingDocumentationGenerator:
                 repository=repository, projects_title_filter=projects_title_filter
             )
 
-            print("PROJECTS FOR REPOSITORY")
-            for project in projects:
-                print(project.title)
-
             if projects:
                 logger.info(
                     "Fetching GitHub project data - for repository `%s` found `%s` project/s.",

--- a/living_documentation_generator/generator.py
+++ b/living_documentation_generator/generator.py
@@ -257,8 +257,7 @@ class LivingDocumentationGenerator:
 
                     # If the key is unique, add the project issue to the dictionary
                     if key not in all_project_issues:
-                        all_project_issues[key] = []
-                        all_project_issues[key].append(project_issue)
+                        all_project_issues[key] = [project_issue]
                     else:
                         # If the project issue key is already present, add another project data from other projects
                         all_project_issues[key].append(project_issue)

--- a/living_documentation_generator/generator.py
+++ b/living_documentation_generator/generator.py
@@ -33,7 +33,6 @@ from living_documentation_generator.model.github_project import GithubProject
 from living_documentation_generator.model.config_repository import ConfigRepository
 from living_documentation_generator.model.consolidated_issue import ConsolidatedIssue
 from living_documentation_generator.model.project_issue import ProjectIssue
-from living_documentation_generator.model.project_status import ProjectStatus
 from living_documentation_generator.utils.decorators import safe_call_decorator
 from living_documentation_generator.utils.github_rate_limiter import GithubRateLimiter
 from living_documentation_generator.utils.utils import make_issue_key
@@ -120,13 +119,15 @@ class LivingDocumentationGenerator:
 
         # Data mine GitHub project's issues
         logger.info("Fetching GitHub project data - started.")
-        project_issues: dict[str, dict[str, ProjectStatus]] = self._fetch_github_project_issues()
+        project_issues: dict[str, list[ProjectIssue]] = self._fetch_github_project_issues()
         # Note: got dict of project issues with unique string key defying the issue
         logger.info("Fetching GitHub project data - finished.")
 
         # Consolidate all issue data together
         logger.info("Issue and project data consolidation - started.")
-        consolidated_issues: dict[str, ConsolidatedIssue] = self._consolidate_issues_data(repository_issues, project_issues)
+        consolidated_issues: dict[str, ConsolidatedIssue] = self._consolidate_issues_data(
+            repository_issues, project_issues
+        )
         logger.info("Issue and project data consolidation - finished.")
 
         # Generate markdown pages
@@ -199,7 +200,7 @@ class LivingDocumentationGenerator:
         )
         return issues
 
-    def _fetch_github_project_issues(self) -> dict[str, dict[str, ProjectStatus]]:
+    def _fetch_github_project_issues(self) -> dict[str, list[ProjectIssue]]:
         """
         Fetch GitHub project issues using the GraphQL API.
 
@@ -212,7 +213,7 @@ class LivingDocumentationGenerator:
         logger.debug("Project data mining allowed.")
 
         # Mine project issues for every repository
-        all_project_issues: dict[str, dict[str, ProjectStatus]] = {}
+        all_project_issues: dict[str, list[ProjectIssue]] = {}
 
         for config_repository in self.repositories:
             repository_id = f"{config_repository.organization_name}/{config_repository.repository_name}"
@@ -228,6 +229,10 @@ class LivingDocumentationGenerator:
             projects: list[GithubProject] = self.__safe_call(self.__github_projects_instance.get_repository_projects)(
                 repository=repository, projects_title_filter=projects_title_filter
             )
+
+            print("PROJECTS FOR REPOSITORY")
+            for project in projects:
+                print(project.title)
 
             if projects:
                 logger.info(
@@ -254,11 +259,13 @@ class LivingDocumentationGenerator:
                         project_issue.number,
                     )
 
+                    # If the key is unique, add the project data status to the repository issue
                     if key not in all_project_issues:
-                        all_project_issues[key] = {}
-                        all_project_issues[key][project.id] = project_issue.project_status
+                        all_project_issues[key] = []
+                        all_project_issues[key].append(project_issue)
                     else:
-                        all_project_issues[key][project.id] = project_issue.project_status
+                        # If the repository issue is already present, add another project data from other projects
+                        all_project_issues[key].append(project_issue)
                 logger.info(
                     "Fetching GitHub project data - successfully fetched project data from `%s`.", project.title
                 )
@@ -267,13 +274,13 @@ class LivingDocumentationGenerator:
 
     @staticmethod
     def _consolidate_issues_data(
-        repository_issues: dict[str, list[Issue]], projects_issues: dict[str, dict[str, ProjectStatus]]
+        repository_issues: dict[str, list[Issue]], project_issues: dict[str, list[ProjectIssue]]
     ) -> dict[str, ConsolidatedIssue]:
         """
         Consolidate the fetched issues and extra project data into a one consolidated object.
 
         @param repository_issues: A dictionary containing repository issue objects with unique key.
-        @param projects_issues: A dictionary containing project issue objects with unique key.
+        @param project_issues: A dictionary containing project issue objects with unique key.
         @return: A dictionary containing all consolidated issues.
         """
 
@@ -291,10 +298,9 @@ class LivingDocumentationGenerator:
         # Update consolidated issue structures with project data
         logger.debug("Updating consolidated issue structure with project data.")
         for key, consolidated_issue in consolidated_issues.items():
-            if key in projects_issues:
-                # Update the consolidated issue with project status data from all projects
-                for project_status in projects_issues[key].values():
-                    consolidated_issue.update_with_project_data(project_status)
+            if key in project_issues:
+                for project_issue in project_issues[key]:
+                    consolidated_issue.update_with_project_data(project_issue.project_status)
 
         logging.info(
             "Issue and project data consolidation - consolidated `%s` repository issues" " with extra project data.",
@@ -417,9 +423,11 @@ class LivingDocumentationGenerator:
         title = consolidated_issue.title
         title = title.replace("|", " _ ")
         page_filename = consolidated_issue.generate_page_filename()
-        status = consolidated_issue.project_status.status
         url = consolidated_issue.html_url
         state = consolidated_issue.state
+
+        status_list = [project_status.status for project_status in consolidated_issue.project_issue_statuses]
+        status = ", ".join(status_list)
 
         # Change the bool values to more user-friendly characters
         if self.__project_state_mining_enabled:
@@ -485,28 +493,29 @@ class LivingDocumentationGenerator:
 
         # Update the summary table, based on the project data mining situation
         if self.__project_state_mining_enabled:
-            project_status = consolidated_issue.project_status
+            project_statuses = consolidated_issue.project_issue_statuses
 
             if consolidated_issue.linked_to_project:
-                headers.extend(
-                    [
-                        "Project title",
-                        "Status",
-                        "Priority",
-                        "Size",
-                        "MoSCoW",
-                    ]
-                )
+                project_data_header = [
+                    "Project title",
+                    "Status",
+                    "Priority",
+                    "Size",
+                    "MoSCoW",
+                ]
 
-                values.extend(
-                    [
+                for project_status in project_statuses:
+                    # Update the summary data table for every project attached to repository issue
+                    project_data_values = [
                         project_status.project_title,
                         project_status.status,
                         project_status.priority,
                         project_status.size,
                         project_status.moscow,
                     ]
-                )
+
+                    headers.extend(project_data_header)
+                    values.extend(project_data_values)
             else:
                 headers.append("Linked to project")
                 linked_to_project = LINKED_TO_PROJECT_FALSE

--- a/living_documentation_generator/generator.py
+++ b/living_documentation_generator/generator.py
@@ -423,7 +423,7 @@ class LivingDocumentationGenerator:
         state = consolidated_issue.state
 
         status_list = [project_status.status for project_status in consolidated_issue.project_issue_statuses]
-        status = ", ".join(status_list)
+        status = ", ".join(status_list) if status_list else "---"
 
         # Change the bool values to more user-friendly characters
         if self.__project_state_mining_enabled:

--- a/living_documentation_generator/generator.py
+++ b/living_documentation_generator/generator.py
@@ -255,12 +255,12 @@ class LivingDocumentationGenerator:
                         project_issue.number,
                     )
 
-                    # If the key is unique, add the project data status to the repository issue
+                    # If the key is unique, add the project issue to the dictionary
                     if key not in all_project_issues:
                         all_project_issues[key] = []
                         all_project_issues[key].append(project_issue)
                     else:
-                        # If the repository issue is already present, add another project data from other projects
+                        # If the project issue key is already present, add another project data from other projects
                         all_project_issues[key].append(project_issue)
                 logger.info(
                     "Fetching GitHub project data - successfully fetched project data from `%s`.", project.title

--- a/living_documentation_generator/model/consolidated_issue.py
+++ b/living_documentation_generator/model/consolidated_issue.py
@@ -44,7 +44,7 @@ class ConsolidatedIssue:
 
         # Extra project data (optionally provided from GithubProjects class)
         self.__linked_to_project: bool = False
-        self.__project_status: ProjectStatus = ProjectStatus()
+        self.__project_issue_statuses: list[ProjectStatus] = []
 
         self.__error: Optional[str] = None
 
@@ -113,9 +113,9 @@ class ConsolidatedIssue:
         return self.__linked_to_project
 
     @property
-    def project_status(self) -> ProjectStatus:
-        """Getter of the project status."""
-        return self.__project_status
+    def project_issue_statuses(self) -> list[ProjectStatus]:
+        """Getter of the project issue statuses."""
+        return self.__project_issue_statuses
 
     # Error property
     @property
@@ -123,19 +123,15 @@ class ConsolidatedIssue:
         """Getter of the error message."""
         return self.__error
 
-    def update_with_project_data(self, project_status: ProjectStatus) -> None:
+    def update_with_project_data(self, project_issue_status: ProjectStatus) -> None:
         """
-        Update the consolidated issue with attached project data.
+        Update the consolidated issue with Project Status data.
 
-        @param project_status: The extra issue project data.
+        @param project_issue_status: The extra issue project data per one project.
         @return: None
         """
         self.__linked_to_project = True
-        self.__project_status.project_title = project_status.project_title
-        self.__project_status.status = project_status.status
-        self.__project_status.priority = project_status.priority
-        self.__project_status.size = project_status.size
-        self.__project_status.moscow = project_status.moscow
+        self.__project_issue_statuses.append(project_issue_status)
 
     def generate_page_filename(self) -> str:
         """

--- a/living_documentation_generator/model/project_issue.py
+++ b/living_documentation_generator/model/project_issue.py
@@ -37,7 +37,6 @@ class ProjectIssue:
         self.__number: int = 0
         self.__organization_name: str = ""
         self.__repository_name: str = ""
-        self.__project_id: str = ""
         self.__project_status: ProjectStatus = ProjectStatus()
 
     @property
@@ -54,11 +53,6 @@ class ProjectIssue:
     def repository_name(self) -> str:
         """Getter of the repository name where the issue was fetched from."""
         return self.__repository_name
-
-    @property
-    def project_id(self) -> str:
-        """Getter of the project ID where the issue belongs."""
-        return self.__project_id
 
     @property
     def project_status(self) -> ProjectStatus:

--- a/living_documentation_generator/model/project_issue.py
+++ b/living_documentation_generator/model/project_issue.py
@@ -37,6 +37,7 @@ class ProjectIssue:
         self.__number: int = 0
         self.__organization_name: str = ""
         self.__repository_name: str = ""
+        self.__project_id: str = ""
         self.__project_status: ProjectStatus = ProjectStatus()
 
     @property
@@ -53,6 +54,11 @@ class ProjectIssue:
     def repository_name(self) -> str:
         """Getter of the repository name where the issue was fetched from."""
         return self.__repository_name
+
+    @property
+    def project_id(self) -> str:
+        """Getter of the project ID where the issue belongs."""
+        return self.__project_id
 
     @property
     def project_status(self) -> ProjectStatus:

--- a/living_documentation_generator/model/project_status.py
+++ b/living_documentation_generator/model/project_status.py
@@ -17,7 +17,6 @@
 """
 This module contains a data container for issue Project Status.
 """
-from typing import Union
 
 from living_documentation_generator.utils.constants import NO_PROJECT_DATA
 
@@ -29,63 +28,53 @@ class ProjectStatus:
     """
 
     def __init__(self):
-        self.__project_title = [NO_PROJECT_DATA]
-        self.__status = [NO_PROJECT_DATA]
-        self.__priority = [NO_PROJECT_DATA]
-        self.__size = [NO_PROJECT_DATA]
-        self.__moscow = [NO_PROJECT_DATA]
+        self.__project_title: str = NO_PROJECT_DATA
+        self.__status: str = NO_PROJECT_DATA
+        self.__priority: str = NO_PROJECT_DATA
+        self.__size: str = NO_PROJECT_DATA
+        self.__moscow: str = NO_PROJECT_DATA
 
     @property
-    def project_title(self) -> list:
+    def project_title(self) -> str:
+        """Getter of the issue attached project title."""
         return self.__project_title
 
     @project_title.setter
-    def project_title(self, value: Union[str, list]):
-        if self.__project_title == [NO_PROJECT_DATA]:
-            self.__project_title = [value]
-        else:
-            self.__project_title.append(value)
+    def project_title(self, value: str):
+        self.__project_title = value
 
     @property
-    def status(self) -> list:
+    def status(self) -> str:
+        """Getter of the issue project status."""
         return self.__status
 
     @status.setter
-    def status(self, value: Union[str, list]):
-        if self.__status == [NO_PROJECT_DATA]:
-            self.__status = [value]
-        else:
-            self.__status.append(value)
+    def status(self, value: str):
+        self.__status = value
 
     @property
-    def priority(self) -> list:
+    def priority(self) -> str:
+        """Getter of the issue project priority."""
         return self.__priority
 
     @priority.setter
-    def priority(self, value: Union[str, list]):
-        if self.__priority == [NO_PROJECT_DATA]:
-            self.__priority = [value]
-        else:
-            self.__priority.append(value)
+    def priority(self, value: str):
+        self.__priority = value
 
     @property
-    def size(self) -> list:
+    def size(self) -> str:
+        """Getter of the issue project difficulty."""
         return self.__size
 
     @size.setter
-    def size(self, value: Union[str, list]):
-        if self.__size == [NO_PROJECT_DATA]:
-            self.__size = [value]
-        else:
-            self.__size.append(value)
+    def size(self, value: str):
+        self.__size = value
 
     @property
-    def moscow(self) -> list:
+    def moscow(self) -> str:
+        """Getter of the issue project MoSCoW prioritization."""
         return self.__moscow
 
     @moscow.setter
-    def moscow(self, value: Union[str, list]):
-        if self.__moscow == [NO_PROJECT_DATA]:
-            self.__moscow = [value]
-        else:
-            self.__moscow.append(value)
+    def moscow(self, value: str):
+        self.__moscow = value

--- a/living_documentation_generator/model/project_status.py
+++ b/living_documentation_generator/model/project_status.py
@@ -17,6 +17,7 @@
 """
 This module contains a data container for issue Project Status.
 """
+from typing import Union
 
 from living_documentation_generator.utils.constants import NO_PROJECT_DATA
 
@@ -28,53 +29,63 @@ class ProjectStatus:
     """
 
     def __init__(self):
-        self.__project_title: str = ""
-        self.__status: str = NO_PROJECT_DATA
-        self.__priority: str = NO_PROJECT_DATA
-        self.__size: str = NO_PROJECT_DATA
-        self.__moscow: str = NO_PROJECT_DATA
+        self.__project_title = [NO_PROJECT_DATA]
+        self.__status = [NO_PROJECT_DATA]
+        self.__priority = [NO_PROJECT_DATA]
+        self.__size = [NO_PROJECT_DATA]
+        self.__moscow = [NO_PROJECT_DATA]
 
     @property
-    def project_title(self) -> str:
-        """Getter of the issue attached project title."""
+    def project_title(self) -> list:
         return self.__project_title
 
     @project_title.setter
-    def project_title(self, value: str):
-        self.__project_title = value
+    def project_title(self, value: Union[str, list]):
+        if self.__project_title == [NO_PROJECT_DATA]:
+            self.__project_title = [value]
+        else:
+            self.__project_title.append(value)
 
     @property
-    def status(self) -> str:
-        """Getter of the issue project status."""
+    def status(self) -> list:
         return self.__status
 
     @status.setter
-    def status(self, value: str):
-        self.__status = value
+    def status(self, value: Union[str, list]):
+        if self.__status == [NO_PROJECT_DATA]:
+            self.__status = [value]
+        else:
+            self.__status.append(value)
 
     @property
-    def priority(self) -> str:
-        """Getter of the issue project priority."""
+    def priority(self) -> list:
         return self.__priority
 
     @priority.setter
-    def priority(self, value: str):
-        self.__priority = value
+    def priority(self, value: Union[str, list]):
+        if self.__priority == [NO_PROJECT_DATA]:
+            self.__priority = [value]
+        else:
+            self.__priority.append(value)
 
     @property
-    def size(self) -> str:
-        """Getter of the issue project difficulty."""
+    def size(self) -> list:
         return self.__size
 
     @size.setter
-    def size(self, value: str):
-        self.__size = value
+    def size(self, value: Union[str, list]):
+        if self.__size == [NO_PROJECT_DATA]:
+            self.__size = [value]
+        else:
+            self.__size.append(value)
 
     @property
-    def moscow(self) -> str:
-        """Getter of the issue project MoSCoW prioritization."""
+    def moscow(self) -> list:
         return self.__moscow
 
     @moscow.setter
-    def moscow(self, value: str):
-        self.__moscow = value
+    def moscow(self, value: Union[str, list]):
+        if self.__moscow == [NO_PROJECT_DATA]:
+            self.__moscow = [value]
+        else:
+            self.__moscow.append(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.black]
 line-length = 120
 target-version = ['py311']
+force-exclude = '''test'''


### PR DESCRIPTION
In GitHub is possible to have more projects assigned from one repository.

This situation can lead to multiple project information availability:
- Status
- Priority
- Size
- MoSCoW

Here is a simulation of this situation: https://github.com/absa-group/living-doc-example-project/issues/89