### PR TITLE
README.md update plus better error handling for No Topic case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the default action step definition:
         "projects-title-filter": ["Community Outreach Initiatives", "CDD Project"]
       }
     ]'
-  ```
+```
 
 See the full example of action step definition (in example are used non-default values):
 
@@ -534,14 +534,14 @@ All done! ✨ 🍰 ✨
 ## Run Unit Test
 
 Unit tests are written using Pytest framework. To run alle the tests, use the following command:
-```bash
+```shell
 pytest tests/
 ```
 
 You can modify the directory to control the level of detail or granularity as per your needs.
 
 To run specific test, write the command following the pattern below:
-```bash
+```shell
 pytest tests/utils/test_utils.py::test_make_issue_key
 ```
 
@@ -551,14 +551,14 @@ This project uses [pytest-cov](https://pypi.org/project/pytest-cov/) plugin to g
 The objective of the project is to achieve a minimal score of 80 %. We do exclude the `tests/` file from the coverage report.
 
 To generate the coverage report, run the following command:
-```bash
+```shell
 pytest --cov=. tests/ --cov-fail-under=80 --cov-report=html
 ```
 
 See the coverage report on the path:
 
-```
-htmlcov/index.html
+```shell
+open htmlcov/index.html
 ```
 
 ## Deployment

--- a/living_documentation_generator/model/consolidated_issue.py
+++ b/living_documentation_generator/model/consolidated_issue.py
@@ -199,7 +199,7 @@ class ConsolidatedIssue:
             # If no label ends with "Topic", create a "NoTopic" issue directory path
             if not topic_labels:
                 self.__topics = ["NoTopic"]
-                logger.error("No Topic label found for Issue #%s: %s (%s)", self.number, self.title, self.repository_id)
+                logger.error("No Topic label found for Issue #%i: %s (%s)", self.number, self.title, self.repository_id)
                 no_topic_path = os.path.join(output_path, "NoTopic")
                 return [no_topic_path]
 

--- a/living_documentation_generator/model/consolidated_issue.py
+++ b/living_documentation_generator/model/consolidated_issue.py
@@ -199,6 +199,7 @@ class ConsolidatedIssue:
             # If no label ends with "Topic", create a "NoTopic" issue directory path
             if not topic_labels:
                 self.__topics = ["NoTopic"]
+                logger.error("No Topic label found for Issue #%s: %s (%s)", self.number, self.title, self.repository_id)
                 no_topic_path = os.path.join(output_path, "NoTopic")
                 return [no_topic_path]
 

--- a/tests/model/test_consolidated_issue.py
+++ b/tests/model/test_consolidated_issue.py
@@ -118,6 +118,7 @@ def test_generate_directory_path_structured_output_disabled_grouping_by_topics_e
 
 
 def test_generate_directory_path_structured_output_disabled_grouping_by_topics_enabled_no_issue_topics(mocker):
+    mock_log_error = mocker.patch("living_documentation_generator.model.consolidated_issue.logger.error")
     mock_log_debug = mocker.patch("living_documentation_generator.model.consolidated_issue.logger.debug")
     mocker.patch(
         "living_documentation_generator.action_inputs.ActionInputs.get_output_directory",
@@ -135,6 +136,9 @@ def test_generate_directory_path_structured_output_disabled_grouping_by_topics_e
     actual = consolidated_issue.generate_directory_path("| Labels | feature, bug |")
 
     assert ["/base/output/path/NoTopic"] == actual
+    mock_log_error.assert_called_once_with(
+        "No Topic label found for Issue #%i: %s (%s)", 1, "Issue Title", "organization/repository"
+    )
     mock_log_debug.assert_not_called()
 
 


### PR DESCRIPTION
Topic feature has been already implemented in https://github.com/AbsaOSS/living-doc-generator/issues/34 .

Adding error message printed when issue has No Topic added.

Release Notes:
- Introduced No Topic chapter, when issue does not have  defined a Topic label.

Closes #54 