### PR TITLE
Feature/74 activate the projects title filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the default action step definition:
 ```yaml
 - name: Generate Living Documentation
   id: generate_living_doc
-  uses: AbsaOSS/living-doc-generator@v0.3.0
+  uses: AbsaOSS/living-doc-generator@v0.4.0
   env:
     GITHUB-TOKEN: ${{ secrets.REPOSITORIES_ACCESS_TOKEN }}  
   with:
@@ -70,7 +70,7 @@ See the full example of action step definition (in example are used non-default 
 ```yaml
 - name: Generate Living Documentation
   id: generate_living_doc
-  uses: AbsaOSS/living-doc-generator@v0.3.0
+  uses: AbsaOSS/living-doc-generator@v0.4.0
   env:
     GITHUB-TOKEN: ${{ secrets.REPOSITORIES_ACCESS_TOKEN }}  
   with:
@@ -89,14 +89,12 @@ See the full example of action step definition (in example are used non-default 
           {
             "organization-name": "health-analytics",
             "repository-name": "patient-data-analysis",
-            "query-labels": ["functionality"],
             "projects-title-filter": ["Health Data Analysis Project"]
           },
           {
             "organization-name": "open-source-initiative",
             "repository-name": "community-driven-project",
-            "query-labels": ["improvement"],
-            "projects-title-filter": ["Community Outreach Initiatives", "CDD Project"] 
+            "query-labels": ["improvement"]
           }
         ]
     liv-doc-project-state-mining: true     # project state mining feature de/activation

--- a/living_documentation_regime/README.md
+++ b/living_documentation_regime/README.md
@@ -38,7 +38,7 @@ See the default minimal Living Documentation regime action step definition:
 ```yaml
 - name: Generate Living Documentation
   id: generate_living_doc
-  uses: AbsaOSS/living-doc-generator@v0.3.0
+  uses: AbsaOSS/living-doc-generator@v0.4.0
   env:
     GITHUB-TOKEN: ${{ secrets.REPOSITORIES_ACCESS_TOKEN }}  
   with:
@@ -47,15 +47,7 @@ See the default minimal Living Documentation regime action step definition:
         [
           {
             "organization-name": "fin-services",
-            "repository-name": "investment-app",
-            "query-labels": ["feature", "enhancement"],
-            "projects-title-filter": []
-          },
-          {
-            "organization-name": "health-analytics",
-            "repository-name": "patient-data-analysis",
-            "query-labels": ["functionality"],
-            "projects-title-filter": ["Health Data Analysis Project"]
+            "repository-name": "investment-app"
           }
         ]
 ```
@@ -65,7 +57,7 @@ See the full example of Living Documentation regime step definition (in example 
 ```yaml
 - name: Generate Living Documentation
   id: generate_living_doc
-  uses: AbsaOSS/living-doc-generator@v0.3.0
+  uses: AbsaOSS/living-doc-generator@v0.4.0
   env:
     GITHUB-TOKEN: ${{ secrets.REPOSITORIES_ACCESS_TOKEN }}  
   with:
@@ -100,7 +92,7 @@ Configure the Living Documentation regime by customizing the following parameter
 ### Regime Inputs
 - **liv-doc-repositories** (optional, `default: '[]'`)
   - **Description**: A JSON string defining the repositories to be included in the documentation generation.
-  - **Usage**: List each repository with its organization name, repository name, query labels and attached projects you want to filter if any. Only projects with these titles will be considered. For no filtering projects, leave the list empty.
+  - **Usage**: Provide a list of repositories including the organization name, repository name, query labels, and any attached projects you wish to filter. The query-labels and projects-title-filter parameters are optional. Only issues with the specified labels and projects will be fetched. To fetch all issues (all labels), either omit these parameters or leave the lists empty.
   - **Example**:
     ```yaml
     with:
@@ -109,13 +101,11 @@ Configure the Living Documentation regime by customizing the following parameter
           {
             "organization-name": "fin-services",
             "repository-name": "investment-app",
-            "query-labels": ["feature", "enhancement"],
-            "projects-title-filter": []
+            "query-labels": ["feature", "enhancement"]
           },
           {
             "organization-name": "open-source-initiative",
             "repository-name": "community-driven-project",
-            "query-labels": ["improvement"],
             "projects-title-filter": ["Community Outreach Initiatives", "CDD Project"] 
           }
         ]

--- a/living_documentation_regime/model/config_repository.py
+++ b/living_documentation_regime/model/config_repository.py
@@ -66,8 +66,8 @@ class ConfigRepository:
         try:
             self.__organization_name = repository_json["organization-name"]
             self.__repository_name = repository_json["repository-name"]
-            self.__query_labels = repository_json["query-labels"]
-            self.__projects_title_filter = repository_json["projects-title-filter"]
+            self.__query_labels = repository_json.get("query-labels", [])
+            self.__projects_title_filter = repository_json.get("projects-title-filter", [])
             return True
         except KeyError as e:
             logger.error("The key is not found in the repository JSON input: %s.", e, exc_info=True)

--- a/tests/living_documentation_regime/model/test_config_repository.py
+++ b/tests/living_documentation_regime/model/test_config_repository.py
@@ -18,6 +18,7 @@ from living_documentation_regime.model.config_repository import ConfigRepository
 
 
 def test_load_from_json_with_valid_input_loads_correctly():
+    # Arrange
     config_repository = ConfigRepository()
     organization_name = "organizationABC"
     repository_name = "repositoryABC"
@@ -32,8 +33,10 @@ def test_load_from_json_with_valid_input_loads_correctly():
         "other-field": other_value,
     }
 
+    # Act
     actual = config_repository.load_from_json(repository_json)
 
+    # Assert
     assert actual
     assert organization_name == config_repository.organization_name
     assert repository_name == config_repository.repository_name
@@ -41,13 +44,37 @@ def test_load_from_json_with_valid_input_loads_correctly():
     assert projects_title_filter == config_repository.projects_title_filter
 
 
-def test_load_from_json_with_missing_key_logs_error(mocker):
+def test_load_from_json_with_valid_input_check_default_values():
+    # Arrange
     config_repository = ConfigRepository()
-    mock_log_error = mocker.patch("living_documentation_regime.model.config_repository.logger.error")
-    repository_json = {"non-existent-key": "value"}
+    organization_name = "organizationABC"
+    repository_name = "repositoryABC"
+    repository_json = {
+        "organization-name": organization_name,
+        "repository-name": repository_name
+    }
 
+    # Act
     actual = config_repository.load_from_json(repository_json)
 
+    # Assert
+    assert actual
+    assert organization_name == config_repository.organization_name
+    assert repository_name == config_repository.repository_name
+    assert [] == config_repository.query_labels
+    assert [] == config_repository.projects_title_filter
+
+
+def test_load_from_json_with_missing_key_logs_error(mocker):
+    # Arrange
+    config_repository = ConfigRepository()
+    repository_json = {"non-existent-key": "value"}
+    mock_log_error = mocker.patch("living_documentation_regime.model.config_repository.logger.error")
+
+    # Act
+    actual = config_repository.load_from_json(repository_json)
+
+    # Assert
     assert actual is False
     mock_log_error.assert_called_once_with(
         "The key is not found in the repository JSON input: %s.", mocker.ANY, exc_info=True
@@ -55,12 +82,15 @@ def test_load_from_json_with_missing_key_logs_error(mocker):
 
 
 def test_load_from_json_with_wrong_structure_input_logs_error(mocker):
+    # Arrange
     config_repository = ConfigRepository()
-    mock_log_error = mocker.patch("living_documentation_regime.model.config_repository.logger.error")
     repository_json = "not a dictionary"
+    mock_log_error = mocker.patch("living_documentation_regime.model.config_repository.logger.error")
 
+    # Act
     actual = config_repository.load_from_json(repository_json)
 
+    # Assert
     assert actual is False
     mock_log_error.assert_called_once_with(
         "The repository JSON input does not have a dictionary structure: %s.", mocker.ANY, exc_info=True


### PR DESCRIPTION
A resolution of issue https://github.com/AbsaOSS/living-doc-generator/issues/74.

Release Notes:
- New logic for writing the configuration without specifying query-labes and project-title-filter.