### PR TITLE
Feature/94 correct action handling of the unsuccessful regime mining

### DIFF
--- a/action_inputs.py
+++ b/action_inputs.py
@@ -21,7 +21,6 @@ which are essential for running the GH action.
 
 import json
 import logging
-import sys
 import requests
 
 from living_documentation_regime.model.config_repository import ConfigRepository
@@ -131,11 +130,11 @@ class ActionInputs:
 
         except json.JSONDecodeError as e:
             logger.error("Error parsing JSON repositories: %s.", e, exc_info=True)
-            raise LivDocFetchRepositoriesException
+            raise LivDocFetchRepositoriesException from e
 
-        except TypeError:
+        except TypeError as e:
             logger.error("Type error parsing input JSON repositories: %s.", repositories_json)
-            raise LivDocFetchRepositoriesException
+            raise LivDocFetchRepositoriesException from e
 
         return repositories
 

--- a/action_inputs.py
+++ b/action_inputs.py
@@ -71,15 +71,6 @@ class ActionInputs:
         regime: str = Regime.LIV_DOC_REGIME.value
         return get_action_input(regime, "false").lower() == "true"
 
-    @staticmethod
-    def get_liv_doc_output_formats() -> list[str]:
-        """
-        Getter of the LivDoc regime output formats for generated documents.
-        @return: A list of LivDoc output formats.
-        """
-        output_formats_string = get_action_input(LIV_DOC_OUTPUT_FORMATS, "mdoc").strip().lower()
-        output_formats = [fmt.strip() for fmt in output_formats_string.split(",")]
-        return output_formats
 
     @staticmethod
     def get_liv_doc_output_formats() -> list[str]:

--- a/action_inputs.py
+++ b/action_inputs.py
@@ -145,10 +145,10 @@ class ActionInputs:
 
         return repositories
 
-    def validate_user_configuration(self) -> None:
+    def validate_user_configuration(self) -> bool:
         """
         Checks that all the user configurations defined are correct.
-        @return: None
+        @return: true if configuration is correct, false otherwise.
         """
         logger.debug("User configuration validation started")
 
@@ -165,7 +165,7 @@ class ActionInputs:
                 response.status_code,
                 response.text,
             )
-            sys.exit(1)
+            return False
 
         repository_error_count = 0
         for repository in repositories:
@@ -194,7 +194,7 @@ class ActionInputs:
                 )
                 repository_error_count += 1
         if repository_error_count > 0:
-            sys.exit(1)
+            return False
 
         # log user configuration
         logger.debug("User configuration validation successfully completed.")
@@ -220,3 +220,5 @@ class ActionInputs:
                 ActionInputs.is_grouping_by_topics_enabled(),
             )
             logger.debug("Regime(LivDoc): `liv-doc-output-formats`: %s.", ActionInputs.get_liv_doc_output_formats())
+
+        return True

--- a/action_inputs.py
+++ b/action_inputs.py
@@ -110,7 +110,8 @@ class ActionInputs:
     def get_repositories() -> list[ConfigRepository]:
         """
         Getter and parser of the Config Repositories.
-        @return: A list of Config Repositories.
+        @return: A list of Config Repositories
+        If getting repository was not successful it will return empty repository
         """
         repositories = []
         repositories_json = get_action_input(LIV_DOC_REPOSITORIES, "[]")
@@ -128,11 +129,11 @@ class ActionInputs:
 
         except json.JSONDecodeError as e:
             logger.error("Error parsing JSON repositories: %s.", e, exc_info=True)
-            sys.exit(1)
+            return list() # todo returning empy list is not the best solution
 
         except TypeError:
             logger.error("Type error parsing input JSON repositories: %s.", repositories_json)
-            sys.exit(1)
+            return list()
 
         return repositories
 
@@ -144,7 +145,9 @@ class ActionInputs:
         logger.debug("User configuration validation started")
 
         # validate repositories configuration
-        repositories: list[ConfigRepository] = self.get_repositories()
+        repositories = self.get_repositories()
+        if not repositories:
+            return False
         github_token = self.get_github_token()
         headers = {"Authorization": f"token {github_token}"}
 
@@ -198,7 +201,7 @@ class ActionInputs:
 
         # log liv-doc regime user inputs
         if ActionInputs.is_living_doc_regime_enabled():
-            logger.debug("Regime(LivDoc): `liv-doc-repositories`: %s.", ActionInputs.get_repositories())
+            logger.debug("Regime(LivDoc): `liv-doc-repositories`: %s.", repositories)
             logger.debug(
                 "Regime(LivDoc): `liv-doc-project-state-mining`: %s.",
                 ActionInputs.is_project_state_mining_enabled(),

--- a/action_inputs.py
+++ b/action_inputs.py
@@ -72,7 +72,6 @@ class ActionInputs:
         regime: str = Regime.LIV_DOC_REGIME.value
         return get_action_input(regime, "false").lower() == "true"
 
-
     @staticmethod
     def get_liv_doc_output_formats() -> list[str]:
         """

--- a/action_inputs.py
+++ b/action_inputs.py
@@ -24,7 +24,7 @@ import logging
 import requests
 
 from living_documentation_regime.model.config_repository import ConfigRepository
-from utils.exceptions import LivDocFetchRepositoriesException
+from utils.exceptions import FetchRepositoriesException
 from utils.utils import get_action_input
 from utils.constants import (
     GITHUB_TOKEN,
@@ -111,8 +111,9 @@ class ActionInputs:
     def get_repositories() -> list[ConfigRepository]:
         """
         Getter and parser of the Config Repositories.
+
         @return: A list of Config Repositories
-        If getting repository was not successful it will return empty repository
+        @raise FetchRepositoriesException: When parsing JSON string to dictionary fails.
         """
         repositories = []
         repositories_json = get_action_input(LIV_DOC_REPOSITORIES, "[]")
@@ -130,25 +131,25 @@ class ActionInputs:
 
         except json.JSONDecodeError as e:
             logger.error("Error parsing JSON repositories: %s.", e, exc_info=True)
-            raise LivDocFetchRepositoriesException from e
+            raise FetchRepositoriesException from e
 
         except TypeError as e:
             logger.error("Type error parsing input JSON repositories: %s.", repositories_json)
-            raise LivDocFetchRepositoriesException from e
+            raise FetchRepositoriesException from e
 
         return repositories
 
     def validate_user_configuration(self) -> bool:
         """
         Checks that all the user configurations defined are correct.
-        @return: true if configuration is correct, false otherwise.
+        @return: True if configuration is correct, False otherwise.
         """
         logger.debug("User configuration validation started")
 
         # validate repositories configuration
         try:
             repositories = self.get_repositories()
-        except LivDocFetchRepositoriesException:
+        except FetchRepositoriesException:
             return False
 
         github_token = self.get_github_token()

--- a/living_documentation_regime/living_documentation_generator.py
+++ b/living_documentation_regime/living_documentation_generator.py
@@ -61,11 +61,11 @@ class LivingDocumentationGenerator:
         self.__rate_limiter: GithubRateLimiter = GithubRateLimiter(self.__github_instance)
         self.__safe_call: Callable = safe_call_decorator(self.__rate_limiter)
 
-    def generate(self) -> None:
+    def generate(self) -> bool:
         """
         Generate the Living Documentation Regime output.
 
-        @return: None
+        @return: true if generation is successful, false otherwise (error occurred).
         """
         self._clean_output_directory()
         logger.debug("Regime's 'LivDoc' output directory cleaned.")
@@ -90,7 +90,7 @@ class LivingDocumentationGenerator:
         logger.info("Issue and project data consolidation - finished.")
 
         # Generate markdown pages
-        self._generate_living_documents(consolidated_issues)
+        return self._generate_living_documents(consolidated_issues)
 
     def _clean_output_directory(self) -> None:
         """
@@ -260,12 +260,12 @@ class LivingDocumentationGenerator:
         )
         return consolidated_issues
 
-    def _generate_living_documents(self, issues: dict[str, ConsolidatedIssue]) -> None:
+    def _generate_living_documents(self, issues: dict[str, ConsolidatedIssue]) -> bool:
         """
         Generate the output in the required formats.
 
         @param issues: A dictionary containing all consolidated issues.
-        @return: None
+        @return: true if generation is successful, false otherwise (error occurred).
         """
         statuses: list[bool] = []
 
@@ -279,5 +279,7 @@ class LivingDocumentationGenerator:
 
         if all(statuses):
             logger.info("Living Documentation output generated successfully.")
+            return True
         else:
             logger.error("Living Documentation output generation failed.")
+            return False

--- a/living_documentation_regime/living_documentation_generator.py
+++ b/living_documentation_regime/living_documentation_generator.py
@@ -33,7 +33,6 @@ from living_documentation_regime.model.github_project import GithubProject
 from living_documentation_regime.model.consolidated_issue import ConsolidatedIssue
 from living_documentation_regime.model.project_issue import ProjectIssue
 from utils.decorators import safe_call_decorator
-from utils.exceptions import LivDocInvalidQueryFormatError
 from utils.github_rate_limiter import GithubRateLimiter
 from utils.utils import make_issue_key
 from utils.constants import (
@@ -66,7 +65,7 @@ class LivingDocumentationGenerator:
         """
         Generate the Living Documentation Regime output.
 
-        @return: true if generation is successful, false otherwise (error occurred).
+        @return: True if generation is successful, False otherwise (error occurred).
         """
         self._clean_output_directory()
         logger.debug("Regime's 'LivDoc' output directory cleaned.")
@@ -79,11 +78,7 @@ class LivingDocumentationGenerator:
 
         # Data mine GitHub project's issues
         logger.info("Fetching GitHub project data - started.")
-        try:
-            project_issues: dict[str, list[ProjectIssue]] = self._fetch_github_project_issues()
-        except LivDocInvalidQueryFormatError:
-            logger.info("Fetching GitHub project data - failed due to invalid query format.")
-            return False
+        project_issues: dict[str, list[ProjectIssue]] = self._fetch_github_project_issues()
         # Note: got dict of project issues with unique string key defying the issue
         logger.info("Fetching GitHub project data - finished.")
 
@@ -274,7 +269,7 @@ class LivingDocumentationGenerator:
         Generate the output in the required formats.
 
         @param issues: A dictionary containing all consolidated issues.
-        @return: true if generation is successful, false otherwise (error occurred).
+        @return: True if generation is successful, False otherwise (error occurred).
         """
         statuses: list[bool] = []
 

--- a/living_documentation_regime/living_documentation_generator.py
+++ b/living_documentation_regime/living_documentation_generator.py
@@ -113,6 +113,7 @@ class LivingDocumentationGenerator:
         total_issues_number = 0
 
         # Run the fetching logic for every config repository
+        # Here is no need for catching exception, because get_repositories is static and it was handle when validating user configuration.
         for config_repository in ActionInputs.get_repositories():
             repository_id = f"{config_repository.organization_name}/{config_repository.repository_name}"
 
@@ -172,6 +173,7 @@ class LivingDocumentationGenerator:
         # Mine project issues for every repository
         all_project_issues: dict[str, list[ProjectIssue]] = {}
 
+        # Here is no need for catching exception, because get_repositories is static and it was handle when validating user configuration.
         for config_repository in ActionInputs.get_repositories():
             repository_id = f"{config_repository.organization_name}/{config_repository.repository_name}"
             projects_title_filter = config_repository.projects_title_filter

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def run() -> None:
         if LivingDocumentationGenerator(output_path).generate():
             logger.info("Living Documentation generator - `LivDoc` generation regime completed successfully.")
         else:
-            logger.info("Living Documentation generator - `LivDoc` generation regime failed.") ## todo error or info?
+            logger.info("Living Documentation generator - `LivDoc` generation regime failed.")
             all_regimes_success = False
     else:
         logger.info("Living Documentation generator - `LivDoc` generation regime disabled.")

--- a/main.py
+++ b/main.py
@@ -40,7 +40,10 @@ def run() -> None:
 
     logger.info("Living Documentation generator - starting.")
 
-    ActionInputs().validate_user_configuration()
+    if not ActionInputs().validate_user_configuration():
+        logger.info("Living Documentation generator - user configuration validation failed.")
+        sys.exit(1)
+
     output_path: str = make_absolute_path(OUTPUT_PATH)
     all_regimes_success: bool = True
 

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ import sys
 from action_inputs import ActionInputs
 from living_documentation_regime.living_documentation_generator import LivingDocumentationGenerator
 from utils.constants import OUTPUT_PATH
+from utils.github_project_queries import validate_query_formats
 from utils.utils import set_action_output, make_absolute_path
 from utils.logging_config import setup_logging
 
@@ -42,6 +43,10 @@ def run() -> None:
 
     if not ActionInputs().validate_user_configuration():
         logger.info("Living Documentation generator - user configuration validation failed.")
+        sys.exit(1)
+
+    if not validate_query_formats():
+        logger.info("Living Documentation generator - query format validation failed.")
         sys.exit(1)
 
     output_path: str = make_absolute_path(OUTPUT_PATH)

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ for the GH Action.
 """
 
 import logging
+import sys
 
 from action_inputs import ActionInputs
 from living_documentation_regime.living_documentation_generator import LivingDocumentationGenerator
@@ -41,14 +42,17 @@ def run() -> None:
 
     ActionInputs().validate_user_configuration()
     output_path: str = make_absolute_path(OUTPUT_PATH)
+    all_regimes_success: bool = True
 
     if ActionInputs.is_living_doc_regime_enabled():
         logger.info("Living Documentation generator - Starting the `LivDoc` generation regime.")
 
         # Generate the Living documentation
-        LivingDocumentationGenerator(output_path).generate()
-
-        logger.info("Living Documentation generator - `LivDoc` generation regime completed.")
+        if LivingDocumentationGenerator(output_path).generate():
+            logger.info("Living Documentation generator - `LivDoc` generation regime completed successfully.")
+        else:
+            logger.info("Living Documentation generator - `LivDoc` generation regime failed.") ## todo error or info?
+            all_regimes_success = False
     else:
         logger.info("Living Documentation generator - `LivDoc` generation regime disabled.")
 
@@ -65,6 +69,9 @@ def run() -> None:
     logger.info("Living Documentation generator - root output path set to `%s`.", output_path)
 
     logger.info("Living Documentation generator - ending.")
+
+    if not all_regimes_success:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/living_documentation_regime/test_action_inputs.py
+++ b/tests/unit/living_documentation_regime/test_action_inputs.py
@@ -20,7 +20,7 @@ import pytest
 
 from action_inputs import ActionInputs
 from living_documentation_regime.model.config_repository import ConfigRepository
-from utils.exceptions import LivDocFetchRepositoriesException
+from utils.exceptions import FetchRepositoriesException
 
 
 # Check Action Inputs default values
@@ -160,7 +160,7 @@ def test_get_repositories_number_instead_of_json(mocker):
     mocker.patch("action_inputs.get_action_input", return_value=1)
 
     # Act & Assert
-    with pytest.raises(LivDocFetchRepositoriesException):
+    with pytest.raises(FetchRepositoriesException):
         ActionInputs.get_repositories()
         mock_log_error.assert_called_once_with("Type error parsing input JSON repositories: %s.", mocker.ANY)
 
@@ -171,7 +171,7 @@ def test_get_repositories_empty_string_as_input(mocker):
     mocker.patch("action_inputs.get_action_input", return_value="")
 
     # Act & Assert
-    with pytest.raises(LivDocFetchRepositoriesException):
+    with pytest.raises(FetchRepositoriesException):
         actual = ActionInputs.get_repositories()
         assert [] == actual
         mock_log_error.assert_called_once_with("Error parsing JSON repositories: %s.", mocker.ANY, exc_info=True)
@@ -184,7 +184,7 @@ def test_get_repositories_invalid_string_as_input(mocker):
     mocker.patch("action_inputs.get_action_input", return_value="not a JSON string")
 
     # Act & Assert
-    with pytest.raises(LivDocFetchRepositoriesException):
+    with pytest.raises(FetchRepositoriesException):
         actual = ActionInputs.get_repositories()
         assert [] == actual
         mock_log_error.assert_called_once_with("Error parsing JSON repositories: %s.", mocker.ANY, exc_info=True)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -24,7 +24,7 @@ from utils.constants import OUTPUT_PATH
 
 def test_run_correct_behaviour_with_all_regimes_enabled(mocker):
     # Arrange
-    mocker.patch("action_inputs.ActionInputs.validate_user_configuration")
+    mocker.patch("action_inputs.ActionInputs.validate_user_configuration", return_value=True)
 
     expected_output_path = os.path.abspath(OUTPUT_PATH)
     mock_log_info = mocker.patch("logging.getLogger").return_value.info
@@ -47,7 +47,7 @@ def test_run_correct_behaviour_with_all_regimes_enabled(mocker):
         [
             mocker.call("Living Documentation generator - starting."),
             mocker.call("Living Documentation generator - Starting the `LivDoc` generation regime."),
-            mocker.call("Living Documentation generator - `LivDoc` generation regime completed."),
+            mocker.call("Living Documentation generator - `LivDoc` generation regime completed successfully."),
             mocker.call("Living Documentation generator - root output path set to `%s`.", expected_output_path),
             mocker.call("Living Documentation generator - ending."),
         ],
@@ -57,7 +57,7 @@ def test_run_correct_behaviour_with_all_regimes_enabled(mocker):
 
 def test_run_with_zero_regimes_enabled(mocker):
     # Arrange
-    mocker.patch("action_inputs.ActionInputs.validate_user_configuration")
+    mocker.patch("action_inputs.ActionInputs.validate_user_configuration", return_value=True)
 
     mock_log_info = mocker.patch("logging.getLogger").return_value.info
     mocker.patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "fake_token", "INPUT_LIV_DOC_REGIME": "false"})

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -78,3 +78,35 @@ def test_run_with_zero_regimes_enabled(mocker):
         ],
         any_order=False,
     )
+
+
+def test_run_regime_failed(mocker):
+    mock_log_info = mocker.patch("logging.getLogger").return_value.info
+    mock_exit = mocker.patch("sys.exit")
+    mocker.patch("action_inputs.ActionInputs.validate_user_configuration", return_value=True)
+    mocker.patch("action_inputs.ActionInputs.is_living_doc_regime_enabled", return_value=True)
+    mocker.patch("main.LivingDocumentationGenerator.generate", return_value=False)
+    expected_output_path = os.path.abspath("./output")  # Adding the default value
+
+    mocker.patch.dict(
+        os.environ,
+        {
+            "INPUT_GITHUB_TOKEN": "fake_token",
+            "INPUT_LIV_DOC_REGIME": "true",
+            "INPUT_OUTPUT_PATH": "./user/output/path",
+        },
+    )
+
+    run()
+
+    mock_log_info.assert_has_calls(
+        [
+            mocker.call("Living Documentation generator - starting."),
+            mocker.call("Living Documentation generator - Starting the `LivDoc` generation regime."),
+            mocker.call("Living Documentation generator - `LivDoc` generation regime failed."),
+            mocker.call("Living Documentation generator - root output path set to `%s`.", expected_output_path),
+            mocker.call("Living Documentation generator - ending."),
+        ],
+        any_order=False,
+    )
+    mock_exit.assert_called_once_with(1)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from utils.exceptions import LivDocInvalidQueryFormatError
 from utils.utils import (
     make_issue_key,
     sanitize_filename,
@@ -85,7 +86,6 @@ def test_get_input_without_hyphen(mocker):
 
 
 def test_validate_query_format_right_behaviour(mocker):
-    mock_exit = mocker.patch("sys.exit", return_value=None)
     mock_log_error = mocker.patch("utils.utils.logger.error")
 
     # Test case where there are no missing or extra placeholders
@@ -93,41 +93,38 @@ def test_validate_query_format_right_behaviour(mocker):
     expected_placeholders = {"placeholder1", "placeholder2"}
     validate_query_format(query_string, expected_placeholders)
     mock_log_error.assert_not_called()
-    mock_exit.assert_not_called()
 
 
 def test_validate_query_format_missing_placeholder(mocker):
-    mock_exit = mocker.patch("sys.exit", return_value=None)
     mock_log_error = mocker.patch("utils.utils.logger.error")
 
     # Test case where there are missing placeholders
     query_string = "This is a query with placeholders {placeholder1} and {placeholder2}"
     expected_placeholders = {"placeholder1", "placeholder2", "placeholder3"}
-    validate_query_format(query_string, expected_placeholders)
-    mock_log_error.assert_called_with(
-        "%s%s\nFor the query: %s",
-        "Missing placeholders: {'placeholder3'}. ",
-        "",
-        "This is a query with placeholders {placeholder1} and {placeholder2}",
-    )
-    mock_exit.assert_called_with(1)
+    with pytest.raises(LivDocInvalidQueryFormatError):
+        validate_query_format(query_string, expected_placeholders)
+        mock_log_error.assert_called_with(
+            "%s%s\nFor the query: %s",
+            "Missing placeholders: {'placeholder3'}. ",
+            "",
+            "This is a query with placeholders {placeholder1} and {placeholder2}",
+        )
 
 
 def test_validate_query_format_extra_placeholder(mocker):
-    mock_exit = mocker.patch("sys.exit", return_value=None)
     mock_log_error = mocker.patch("utils.utils.logger.error")
 
     # Test case where there are extra placeholders
     query_string = "This is a query with placeholders {placeholder1} and {placeholder2}"
     expected_placeholders = {"placeholder1"}
-    validate_query_format(query_string, expected_placeholders)
-    mock_log_error.assert_called_with(
-        "%s%s\nFor the query: %s",
-        "",
-        "Extra placeholders: {'placeholder2'}.",
-        "This is a query with placeholders {placeholder1} and {placeholder2}",
-    )
-    mock_exit.assert_called_with(1)
+    with pytest.raises(LivDocInvalidQueryFormatError):
+        validate_query_format(query_string, expected_placeholders)
+        mock_log_error.assert_called_with(
+            "%s%s\nFor the query: %s",
+            "",
+            "Extra placeholders: {'placeholder2'}.",
+            "This is a query with placeholders {placeholder1} and {placeholder2}",
+        )
 
 
 # set_action_output

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from utils.exceptions import LivDocInvalidQueryFormatError
+from utils.exceptions import InvalidQueryFormatError
 from utils.utils import (
     make_issue_key,
     sanitize_filename,
@@ -101,7 +101,7 @@ def test_validate_query_format_missing_placeholder(mocker):
     # Test case where there are missing placeholders
     query_string = "This is a query with placeholders {placeholder1} and {placeholder2}"
     expected_placeholders = {"placeholder1", "placeholder2", "placeholder3"}
-    with pytest.raises(LivDocInvalidQueryFormatError):
+    with pytest.raises(InvalidQueryFormatError):
         validate_query_format(query_string, expected_placeholders)
         mock_log_error.assert_called_with(
             "%s%s\nFor the query: %s",
@@ -117,7 +117,7 @@ def test_validate_query_format_extra_placeholder(mocker):
     # Test case where there are extra placeholders
     query_string = "This is a query with placeholders {placeholder1} and {placeholder2}"
     expected_placeholders = {"placeholder1"}
-    with pytest.raises(LivDocInvalidQueryFormatError):
+    with pytest.raises(InvalidQueryFormatError):
         validate_query_format(query_string, expected_placeholders)
         mock_log_error.assert_called_with(
             "%s%s\nFor the query: %s",

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -22,7 +22,7 @@ from utils.utils import (
     validate_query_format,
     get_action_input,
     set_action_output,
-    set_action_failed, load_template, generate_root_level_index_page,
+    load_template, generate_root_level_index_page,
 )
 
 
@@ -155,17 +155,6 @@ def test_set_output_custom_path(mocker):
     handle.write.assert_any_call("custom-output=custom_value\n")
 
 
-# set_action_failed
-
-
-def test_set_failed(mocker):
-    mock_print = mocker.patch("builtins.print", return_value=None)
-    mock_exit = mocker.patch("sys.exit", return_value=None)
-
-    set_action_failed("failure message")
-
-    mock_print.assert_called_with("::error::failure message")
-    mock_exit.assert_called_with(1)
 
 
 # generate_root_level_index_page

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -18,10 +18,14 @@
 This module contains custom exceptions for this project
 """
 
+
 class LivDocException(Exception):
     """Base class for exceptions in this project."""
+
     pass
+
 
 class LivDocFetchRepositoriesException(LivDocException):
     """Raised when fetching repositories fails in get_repositories()."""
+
     pass

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -19,13 +19,13 @@ This module contains custom exceptions for this project
 """
 
 
-class LivDocException(Exception):
+class LivingDocumentationGeneratorException(Exception):
     """Base class for exceptions in this project."""
 
 
-class LivDocFetchRepositoriesException(LivDocException):
+class FetchRepositoriesException(LivingDocumentationGeneratorException):
     """Raised when fetching repositories fails in get_repositories()."""
 
 
-class LivDocInvalidQueryFormatError(LivDocException):
+class InvalidQueryFormatError(LivingDocumentationGeneratorException):
     """Raised when a query string is missing or has unexpected placeholders."""

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2024 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This module contains custom exceptions for this project
+"""
+
+class LivDocException(Exception):
+    """Base class for exceptions in this project."""
+    pass
+
+class LivDocFetchRepositoriesException(LivDocException):
+    """Raised when fetching repositories fails in get_repositories()."""
+    pass

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -22,10 +22,10 @@ This module contains custom exceptions for this project
 class LivDocException(Exception):
     """Base class for exceptions in this project."""
 
-    pass
-
 
 class LivDocFetchRepositoriesException(LivDocException):
     """Raised when fetching repositories fails in get_repositories()."""
 
-    pass
+
+class LivDocInvalidQueryFormatError(LivDocException):
+    """Raised when a query string is missing or has unexpected placeholders."""

--- a/utils/github_project_queries.py
+++ b/utils/github_project_queries.py
@@ -17,7 +17,7 @@
 """
 This module contains methods for formating the GitHub GraphQL queries.
 """
-
+from utils.exceptions import InvalidQueryFormatError
 from utils.utils import validate_query_format
 from utils.constants import (
     PROJECTS_FROM_REPO_QUERY,
@@ -26,16 +26,26 @@ from utils.constants import (
     ISSUES_PER_PAGE_LIMIT,
 )
 
+def validate_query_formats() -> bool:
+    """
+    Validate the format of the queries
+    @return: True if the queries are in the correct format, False otherwise
+    """
+    try:
+        validate_query_format(PROJECTS_FROM_REPO_QUERY, {"organization_name", "repository_name"})
+        validate_query_format(ISSUES_FROM_PROJECT_QUERY, {"project_id", "issues_per_page", "after_argument"})
+        validate_query_format(PROJECT_FIELD_OPTIONS_QUERY, {"organization_name", "repository_name", "project_number"})
+    except InvalidQueryFormatError:
+        return False
+    return True
 
 def get_projects_from_repo_query(organization_name: str, repository_name: str) -> str:
     """Update the placeholder values and formate the graphQL query"""
-    validate_query_format(PROJECTS_FROM_REPO_QUERY, {"organization_name", "repository_name"})
     return PROJECTS_FROM_REPO_QUERY.format(organization_name=organization_name, repository_name=repository_name)
 
 
 def get_issues_from_project_query(project_id: str, after_argument: str) -> str:
     """Update the placeholder values and formate the graphQL query"""
-    validate_query_format(ISSUES_FROM_PROJECT_QUERY, {"project_id", "issues_per_page", "after_argument"})
     return ISSUES_FROM_PROJECT_QUERY.format(
         project_id=project_id, issues_per_page=ISSUES_PER_PAGE_LIMIT, after_argument=after_argument
     )
@@ -43,7 +53,6 @@ def get_issues_from_project_query(project_id: str, after_argument: str) -> str:
 
 def get_project_field_options_query(organization_name: str, repository_name: str, project_number: int) -> str:
     """Update the placeholder values and formate the graphQL query"""
-    validate_query_format(PROJECT_FIELD_OPTIONS_QUERY, {"organization_name", "repository_name", "project_number"})
     return PROJECT_FIELD_OPTIONS_QUERY.format(
         organization_name=organization_name, repository_name=repository_name, project_number=project_number
     )

--- a/utils/github_project_queries.py
+++ b/utils/github_project_queries.py
@@ -26,6 +26,7 @@ from utils.constants import (
     ISSUES_PER_PAGE_LIMIT,
 )
 
+
 def validate_query_formats() -> bool:
     """
     Validate the format of the queries
@@ -38,6 +39,7 @@ def validate_query_formats() -> bool:
     except InvalidQueryFormatError:
         return False
     return True
+
 
 def get_projects_from_repo_query(organization_name: str, repository_name: str) -> str:
     """Update the placeholder values and formate the graphQL query"""

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -24,7 +24,7 @@ import sys
 import logging
 from typing import Optional
 
-from utils.exceptions import LivDocInvalidQueryFormatError
+from utils.exceptions import InvalidQueryFormatError
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ def validate_query_format(query_string, expected_placeholders) -> None:
     @param query_string: The query string to validate.
     @param expected_placeholders: The set of expected placeholders in the query.
     @return: None
+    @raise InvalidQueryFormatError: When some placeholders are missing in the query.
     """
     actual_placeholders = set(re.findall(r"\{(\w+)\}", query_string))
     missing = expected_placeholders - actual_placeholders
@@ -90,7 +91,7 @@ def validate_query_format(query_string, expected_placeholders) -> None:
         missing_message = f"Missing placeholders: {missing}. " if missing else ""
         extra_message = f"Extra placeholders: {extra}." if extra else ""
         logger.error("%s%s\nFor the query: %s", missing_message, extra_message, query_string)
-        raise LivDocInvalidQueryFormatError
+        raise InvalidQueryFormatError
 
 
 def generate_root_level_index_page(index_root_level_page: str, output_path: str) -> None:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -24,6 +24,8 @@ import sys
 import logging
 from typing import Optional
 
+from utils.exceptions import LivDocInvalidQueryFormatError
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,7 +90,7 @@ def validate_query_format(query_string, expected_placeholders) -> None:
         missing_message = f"Missing placeholders: {missing}. " if missing else ""
         extra_message = f"Extra placeholders: {extra}." if extra else ""
         logger.error("%s%s\nFor the query: %s", missing_message, extra_message, query_string)
-        sys.exit(1)  # todo
+        raise LivDocInvalidQueryFormatError
 
 
 def generate_root_level_index_page(index_root_level_page: str, output_path: str) -> None:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -148,12 +148,3 @@ def set_action_output(name: str, value: str, default_output_path: str = "default
         f.write(f"{name}={value}\n")
 
 
-def set_action_failed(message: str) -> None:
-    """
-    Set the action as failed with the provided message.
-
-    @param message: The error message to display.
-    @return: None
-    """
-    print(f"::error::{message}")
-    sys.exit(1)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -88,7 +88,7 @@ def validate_query_format(query_string, expected_placeholders) -> None:
         missing_message = f"Missing placeholders: {missing}. " if missing else ""
         extra_message = f"Extra placeholders: {extra}." if extra else ""
         logger.error("%s%s\nFor the query: %s", missing_message, extra_message, query_string)
-        sys.exit(1)
+        sys.exit(1)  # todo
 
 
 def generate_root_level_index_page(index_root_level_page: str, output_path: str) -> None:
@@ -146,5 +146,3 @@ def set_action_output(name: str, value: str, default_output_path: str = "default
     output_file = os.getenv("GITHUB_OUTPUT", default_output_path)
     with open(output_file, "a", encoding="utf-8") as f:
         f.write(f"{name}={value}\n")
-
-


### PR DESCRIPTION
Remove all `sys.exit(1)` calls except calls from main.

Release notes:
- Remove `sys.exit()` from  `get_repositories` `validate_user_configuration` `validate_query_format` and tests
- Add exception.py file 

Closes #94 